### PR TITLE
doc: Add `core` tag in commit message table

### DIFF
--- a/COMMIT_MESSAGE_GUIDELINES.md
+++ b/COMMIT_MESSAGE_GUIDELINES.md
@@ -49,6 +49,7 @@ Use the following tags at the start of your commit message:
 
 | Type       | Description                                          |
 | ---------- | ---------------------------------------------------- |
+| `core`     | Introduce a core functionality                                    |
 | `feat`     | Add a new feature                                    |
 | `fix`      | Fix a bug                                            |
 | `docs`     | Update documentation                                 |


### PR DESCRIPTION
- this commit tag has been used in many commits like ce88303b3eb68df810bac4a19d0d0787a9b64740 ,
c9aa5119edcf2199f6b1db16617c43a520ea2874